### PR TITLE
fixed issue with cert resources not able to define encryption on read…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The following resources will be created:
 | subnet\_ids | Subnet ID to associate clients (each subnet passed will create an VPN association - costs involved) | `list(string)` | n/a | yes |
 | tags | Extra tags to attach to resources | `map(string)` | `{}` | no |
 | vpc\_id | VPC Id to create resources | `string` | n/a | yes |
+| transport\_protocol | (Optional) The transport protocol to be used by the VPN session. (Default value is `udp`). | `string` | udp | no |
+
+| session_timeout_hours | (Optional) The maximum session duration is a trigger by which end-users are required to re-authenticate prior to establishing a VPN session. (Default value is `24` - Valid values: `8` | `10` | `12` | `24`) | `number` | `24` | no |
+| login_banner_text | (Optional) Customizable text that will be displayed in a banner on AWS provided clients when a VPN session is established. UTF-8 encoded characters only. Maximum of 1400 characters. | `string` | `null` | no |
+
 
 ## Outputs
 
@@ -53,6 +58,7 @@ The following resources will be created:
 | vpn\_client\_cert | n/a |
 | vpn\_client\_key | n/a |
 | vpn\_endpoint\_id | n/a |
+| vpn\_dns\_name | n/a |
 
 <!--- END_TF_DOCS --->
 

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -10,3 +10,6 @@ output "vpn_client_cert" {
 output "vpn_client_key" {
   value = tls_private_key.root.private_key_pem
 }
+output "vpn_dns_name" {
+  value = aws_ec2_client_vpn_endpoint.default.dns_name
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -74,3 +74,22 @@ variable "enable_self_service_portal" {
   default     = false
   description = "Specify whether to enable the self-service portal for the Client VPN endpoint"
 }
+
+variable "transport_protocol" {
+  type        = string
+  default     = "udp"
+  description = "(Optional) The transport protocol to be used by the VPN session. (Default value is `udp`)."
+}
+
+variable "session_timeout_hours" {
+  type        = number
+  default     = 24
+  description = "(Optional) The maximum session duration is a trigger by which end-users are required to re-authenticate prior to establishing a VPN session. (Default value is `24` - Valid values: `8` | `10` | `12` | `24`)"
+}
+
+variable "login_banner_text" {
+  type        = string
+  default     = null
+  description = "(Optional) Customizable text that will be displayed in a banner on AWS provided clients when a VPN session is established. UTF-8 encoded characters only. Maximum of 1400 characters."
+}
+

--- a/acm-certificate-ca.tf
+++ b/acm-certificate-ca.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "ca" {
 }
 
 resource "tls_self_signed_cert" "ca" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.ca.private_key_pem
 
   subject {

--- a/acm-certificate-root.tf
+++ b/acm-certificate-root.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "root" {
 }
 
 resource "tls_cert_request" "root" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.root.private_key_pem
 
   subject {
@@ -14,7 +13,6 @@ resource "tls_cert_request" "root" {
 
 resource "tls_locally_signed_cert" "root" {
   cert_request_pem   = tls_cert_request.root.cert_request_pem
-  ca_key_algorithm   = "RSA"
   ca_private_key_pem = tls_private_key.ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
 

--- a/acm-certificate-server.tf
+++ b/acm-certificate-server.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "server" {
 }
 
 resource "tls_cert_request" "server" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.server.private_key_pem
 
   subject {
@@ -14,7 +13,6 @@ resource "tls_cert_request" "server" {
 
 resource "tls_locally_signed_cert" "server" {
   cert_request_pem   = tls_cert_request.server.cert_request_pem
-  ca_key_algorithm   = "RSA"
   ca_private_key_pem = tls_private_key.ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
 

--- a/vpn-endpoint.tf
+++ b/vpn-endpoint.tf
@@ -5,6 +5,8 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
   split_tunnel           = var.split_tunnel
   dns_servers            = var.dns_servers
   self_service_portal    = local.self_service_portal
+  transport_protocol     = var.transport_protocol
+  session_timeout_hours  = var.session_timeout_hours
 
   authentication_options {
     type                       = var.authentication_type
@@ -16,6 +18,14 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
     enabled               = true
     cloudwatch_log_group  = aws_cloudwatch_log_group.vpn.name
     cloudwatch_log_stream = aws_cloudwatch_log_stream.vpn.name
+  }
+
+  dynamic "client_login_banner_options" {
+    for_each = var.login_banner_text == null? [] : [var.login_banner_text]
+    content {
+      banner_text = var.login_banner_text
+      enabled = true 
+    }
   }
 
   tags = merge(


### PR DESCRIPTION

## Big picture
> Updates made to provide more access to configure the vpn and address restriction with the certs that blocked usage of this module in newer Terraform versions. 

## Types of changes

#### Bugfix (non-breaking change which fixes an issue)
- [x]  fixed issue with cert resources not able to define encryption on readonly

#### New feature (non-breaking change which adds functionality)
- [x] Added variable support for `transport_protocol`, `session_timeout_hours`, and `login_banner_text`
- [x] updated output with dns name
- [x] Updated documentation to reflect the changes. 

