### PR TITLE
fix(provider): aws provider marked these read-only

### DIFF
--- a/acm-certificate-ca.tf
+++ b/acm-certificate-ca.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "ca" {
 }
 
 resource "tls_self_signed_cert" "ca" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.ca.private_key_pem
 
   subject {

--- a/acm-certificate-root.tf
+++ b/acm-certificate-root.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "root" {
 }
 
 resource "tls_cert_request" "root" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.root.private_key_pem
 
   subject {
@@ -14,7 +13,6 @@ resource "tls_cert_request" "root" {
 
 resource "tls_locally_signed_cert" "root" {
   cert_request_pem   = tls_cert_request.root.cert_request_pem
-  ca_key_algorithm   = "RSA"
   ca_private_key_pem = tls_private_key.ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
 

--- a/acm-certificate-server.tf
+++ b/acm-certificate-server.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "server" {
 }
 
 resource "tls_cert_request" "server" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.server.private_key_pem
 
   subject {
@@ -14,7 +13,6 @@ resource "tls_cert_request" "server" {
 
 resource "tls_locally_signed_cert" "server" {
   cert_request_pem   = tls_cert_request.server.cert_request_pem
-  ca_key_algorithm   = "RSA"
   ca_private_key_pem = tls_private_key.ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
 


### PR DESCRIPTION
The latest AWS provider has made the key_algorithm variable read-only so you can't set it in code at all anymore.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments

This is a small change simple to get this working again.