### PR TITLE
Mark outputted keys as sensitive

### DIFF
--- a/_outputs.tf
+++ b/_outputs.tf
@@ -8,17 +8,20 @@ output "vpn_client_cert" {
   value = tls_locally_signed_cert.root.cert_pem
 }
 output "vpn_client_key" {
-  value = tls_private_key.root.private_key_pem
+  value     = tls_private_key.root.private_key_pem
+  sensitive = true
 }
 output "vpn_server_cert" {
   value = tls_locally_signed_cert.server.cert_pem
 }
 output "vpn_server_key" {
-  value = tls_private_key.server.private_key_pem
+  value     = tls_private_key.server.private_key_pem
+  sensitive = true
 }
 output "vpn_ca_cert" {
   value = tls_self_signed_cert.ca.cert_pem
 }
 output "vpn_ca_key" {
-  value = tls_private_key.ca.private_key_pem
+  value     = tls_private_key.ca.private_key_pem
+  sensitive = true
 }


### PR DESCRIPTION
The module is failing on Terraform 1.0 because as of 0.14 sensitive outputs must be marked as such. This PR aims to fix that.

To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output containing sensitive data be explicitly marked as sensitive, to confirm your intent. If you do intend to export this data, annotate the output value as sensitive by adding the `sensitive = true` argument.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

Full Terragrunt error log:

```
│ Error: Output refers to sensitive values
│ 
│   on _outputs.tf line 10:
│   10: output "vpn_client_key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
╷
│ Error: Output refers to sensitive values
│ 
│   on _outputs.tf line 16:
│   16: output "vpn_server_key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
╷
│ Error: Output refers to sensitive values
│ 
│   on _outputs.tf line 22:
│   22: output "vpn_ca_key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```