### PR TITLE
Fix/warning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+    - 'enhancement'
+  patch:
+    labels:
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
+  default: 'minor'
+
+categories:
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Automatic Updates'
+  labels:
+  - 'auto-update'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+    $BODY
+  </details>
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,23 @@
+name: auto-release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Get PR from merged commit to master
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/vpn-endpoint.tf
+++ b/vpn-endpoint.tf
@@ -5,6 +5,7 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
   split_tunnel           = var.split_tunnel
   dns_servers            = var.dns_servers
   self_service_portal    = local.self_service_portal
+  security_group_ids     = [var.security_group_id == "" ? aws_security_group.default[0].id : var.security_group_id]
 
   authentication_options {
     type                       = var.authentication_type
@@ -31,7 +32,6 @@ resource "aws_ec2_client_vpn_network_association" "default" {
   count                  = length(var.subnet_ids)
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.default.id
   subnet_id              = element(var.subnet_ids, count.index)
-  security_groups        = [var.security_group_id == "" ? aws_security_group.default[0].id : var.security_group_id]
 }
 
 resource "aws_ec2_client_vpn_authorization_rule" "all_groups" {


### PR DESCRIPTION
Updated security group ids argument to remove the warning below.

```
Warning: Argument is deprecated

with module.vpn[0].aws_ec2_client_vpn_network_association.default[0],
on modules/terraform-aws-client-vpn/vpn-endpoint.tf line 34, in resource "aws_ec2_client_vpn_network_association" "default":
34:   security_groups        = [var.security_group_id == "" ? aws_security_group.default[0].id : var.security_group_id]

Use the `security_group_ids` attribute of the `aws_ec2_client_vpn_endpoint` resource instead.
```


## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added the necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...