### PR TITLE
ISSUE #25 Adds VPC ID in client VPN endpoint argument

### DIFF
--- a/vpn-endpoint.tf
+++ b/vpn-endpoint.tf
@@ -6,6 +6,7 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
   dns_servers            = var.dns_servers
   self_service_portal    = local.self_service_portal
   security_group_ids     = [var.security_group_id == "" ? aws_security_group.default[0].id : var.security_group_id]
+  vpc_id                 = var.vpc_id
 
   authentication_options {
     type                       = var.authentication_type


### PR DESCRIPTION
Solves the issue reported https://github.com/DNXLabs/terraform-aws-client-vpn/issues/25

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

This fix is necessary to get main upstream repo working. As of now the present upstream branch is broken.