### PR TITLE
Added options for managing connection authorization for new client connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The following resources will be created:
 | authentication\_saml\_provider\_arn | (Optional) The ARN of the IAM SAML identity provider if type is federated-authentication. | `any` | `null` | no |
 | authentication\_type | The type of client authentication to be used. Specify certificate-authentication to use certificate-based authentication, directory-service-authentication to use Active Directory authentication, or federated-authentication to use Federated Authentication via SAML 2.0. | `string` | `"certificate-authentication"` | no |
 | cidr | Network CIDR to use for clients | `any` | n/a | yes |
+| client\_connect\_options | Indicates whether client connect options are enabled | `bool` | `false` | no |
+| connection\_authorization\_lambda\_function\_arn | The Amazon Resource Name (ARN) of the Lambda function used for connection authorization. | `any` | `null` | no |
 | dns\_servers | List of DNS Servers | `list(string)` | `[]` | no |
 | enable\_self\_service\_portal | Specify whether to enable the self-service portal for the Client VPN endpoint | `bool` | `false` | no |
 | logs\_retention | Retention in days for CloudWatch Log Group | `number` | `365` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -74,3 +74,14 @@ variable "enable_self_service_portal" {
   default     = false
   description = "Specify whether to enable the self-service portal for the Client VPN endpoint"
 }
+
+variable "client_connect_options" {
+  type = bool
+  default = false
+  description = "Indicates whether client connect options are enabled"  
+}
+
+variable "connection_authorization_lambda_function_arn" {
+  default = null
+  description = "The Amazon Resource Name (ARN) of the Lambda function used for connection authorization."  
+}

--- a/vpn-endpoint.tf
+++ b/vpn-endpoint.tf
@@ -20,6 +20,11 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
     cloudwatch_log_stream = aws_cloudwatch_log_stream.vpn.name
   }
 
+  client_connect_options {
+    enabled             = var.client_connect_options
+    lambda_function_arn = var.client_connect_options != true ? null : var.connection_authorization_lambda_function_arn
+  }
+  
   tags = merge(
     var.tags,
     tomap({


### PR DESCRIPTION
Allow to use of an AWS Lambda function that is invoked synchronously by the service (after user and device authentication) when a new VPN session connection is attempted by an end user. The Lambda function can be customized to enforce the security policies of the enterprise.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments